### PR TITLE
Specify gateway version 6

### DIFF
--- a/app.ino
+++ b/app.ino
@@ -115,7 +115,7 @@ void loop()
     {
         Serial.println("connecting");
         // It technically should fetch url from discord.com/api/gateway
-        ws.connect("gateway.discord.gg", "https://gateway.discord.gg/", 443);
+        ws.connect("gateway.discord.gg", "https://gateway.discord.gg/?v=6&encoding=json", 443);
     }
     else
     {


### PR DESCRIPTION
Specify Gateway version 6 to prevent using version 8, which requires the use of [intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).

May resolve #12 ¯\\\_(ツ)\_/¯