### PR TITLE
Update to ESP8266 Core v2.7.4, fix SSL connection issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+privateConfig.h

--- a/.vscode/arduino.json
+++ b/.vscode/arduino.json
@@ -1,7 +1,13 @@
 {
     "sketch": "app.ino",
     "board": "esp8266:esp8266:huzzah",
-    "configuration": "CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=none,UploadSpeed=512000",
+    "configuration": "xtal=80,vt=flash,exception=legacy,ssl=all,eesz=4M2M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=115200",
     "port": "COM3",
-    "output": "../build/esp-discord-client"
+    "output": "../build/esp-discord-client",
+    "buildPreferences": [
+        [
+            "build.extra_flags",
+            "-DDEBUG_ESP_SSL -DDEBUG_ESP_PORT=Serial"
+        ]
+    ]
 }

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "Win32",
             "includePath": [
                 "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\tools\\\\**",
-                "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\hardware\\\\esp8266\\\\2.4.2\\\\**"
+                "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\hardware\\\\esp8266\\\\2.7.4\\\\**"
             ],
             "forcedInclude": [],
             "intelliSenseMode": "msvc-x64",
@@ -15,7 +15,7 @@
                 "limitSymbolsToIncludedHeaders": false,
                 "path": [
                     "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\tools\\\\**",
-                    "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\hardware\\\\esp8266\\\\2.4.2\\\\**"
+                    "C:\\\\Users\\\\Tim\\\\AppData\\\\Local\\\\Arduino15\\\\packages\\\\esp8266\\\\hardware\\\\esp8266\\\\2.7.4\\\\**"
                 ]
             }
         }

--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ See the [`mute_led`](https://github.com/Cimera42/esp-discord-client/tree/mute_le
 
 1. Install ESP board for Arduino as outlined on the [official documentation](https://arduino-esp8266.readthedocs.io/en/latest/installing.html)
 
-2. Set configuration at the top of `app.ino`.
+2. Copy `privateConfig.template.h` and rename to `privateConfig.h`.
 
-    |Name|Value|
-    |-|-|
-    |`wifi_ssid`|SSID of the wifi to connect to|
-    |`wifi_password`|Password for the wifi to connect to|
-    |`bot_token`|Token to authenticate websocket connection<br/>Discord bots can be created and tokens generated at the [Developer Documentation](https://discord.com/developers/applications).|
-    |`gateway_intents`|Data to be sent over websocket connection<br/>Options can be found in [`GatewayIntents.h`](./GatewayIntents.h)<br/>  - Bitwise OR (`\|`) for multiple.<br/>More info can be found at: https://discord.com/developers/docs/topics/gateway#gateway-intents|
+3. Set configuration in `config.h` and `privateConfig.h`.
+
+    |Name|Value|Location|
+    |-|-|-|
+    |`wifi_ssid`|SSID of the wifi to connect to|`privateConfig.h`|
+    |`wifi_password`|Password for the wifi to connect to|`privateConfig.h`|
+    |`bot_token`|Token to authenticate websocket connection<br/>Discord bots can be created and tokens generated at the [Developer Documentation](https://discord.com/developers/applications).|`privateConfig.h`|
+    |`gateway_intents`|Data to be sent over websocket connection<br/>Options can be found in [`GatewayIntents.h`](./GatewayIntents.h)<br/>  - Bitwise OR (`\|`) for multiple.<br/>More info can be found at: https://discord.com/developers/docs/topics/gateway#gateway-intents|`config.h`|
 
 
-3. Build and upload to ESP board
+4. Build and upload to ESP board
 
 - If there are any problems, feel free to create an [issue on GitHub](https://github.com/Cimera42/esp-discord-client/issues)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ See the [`mute_led`](https://github.com/Cimera42/esp-discord-client/tree/mute_le
     |`bot_token`|Token to authenticate websocket connection<br/>Discord bots can be created and tokens generated at the [Developer Documentation](https://discord.com/developers/applications).|`privateConfig.h`|
     |`gateway_intents`|Data to be sent over websocket connection<br/>Options can be found in [`GatewayIntents.h`](./GatewayIntents.h)<br/>  - Bitwise OR (`\|`) for multiple.<br/>More info can be found at: https://discord.com/developers/docs/topics/gateway#gateway-intents|`config.h`|
 
-
 4. Build and upload to ESP board
 
 - If there are any problems, feel free to create an [issue on GitHub](https://github.com/Cimera42/esp-discord-client/issues)
@@ -40,11 +39,36 @@ Here's some common problems which may be preventing the client from working prop
 
 Due to the limited memory of the ESP8266, some websocket messages may be too large and crash the program. For this reason, it is not recommended to use the `GUILDS_INTENT` intent, as it includes a message of the full state of the bot's guilds when connecting the websocket client.
 
+### Incorrect SSL fingerprint
+
+If the WebSocket gets into a loop connecting, you may need to update the SSL certificate fingerprint.
+
+1. Enable debugging of SSL through the `DEBUG_ESP_SSL` and `DEBUG_ESP_PORT=Serial` defines.
+
+    (These will have to be set in such a way that they affect the library, e.g. `arduino.json / buildPreferences / build.extra_flags` for VSCode, `preferences.txt` for Arduino IDE).
+
+2. Ensure the `certificateFingerprint` in `config.h` is set to a valid fingerprint format (20 pairs of hexadecimal characters).
+
+    This makes sure the library should print out the correct token we want.
+
+3. Run the application and connect to the serial log
+
+4. Copy the `received` fingerprint from the serial log into `certificateFingerprint` in `config.h`.
+
+    Example output:
+    ```
+    BSSL:insecure_end_chain: Received cert FP doesn't match
+    BSSL:insecure_end_chain: expected 65 35 f4 58 de 33 46 2d 16 1e 4b 35 c1 f1 97 8f 95 b2 3a 18
+    BSSL:insecure_end_chain: received 2c 9f 73 11 96 d1 d6 ab 00 4d 2e f1 2c 4e 12 37 96 17 27 93
+    ```
+
 ## Used Libraries:
 ### [esp8266-websocketclient](https://github.com/hellerchr/esp8266-websocketclient)
 Some custom modifications:
 - Accept lowercase http headers
 - Non-blocking `getMessage`
+- Allow setting WiFiClientSecure SSL Fingerprint
+- Log message when client connection fails
 
 ### [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
 Used to decode JSON payloads from Discord.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Some custom modifications:
 ### [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
 Used to decode JSON payloads from Discord.
 
+### [ESP8266 Arduino core - v2.7.4](https://github.com/esp8266/Arduino/releases/tag/2.7.4)
+Arduino core for ESP8266 WiFi chip
+
 ## Other Resources
 
 Based on https://github.com/Cimera42/DiscordBot

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -22,16 +22,20 @@ public:
 
 	void setAuthorizationHeader(String header);
 
+	void setSecureFingerprint(const char * fpStr);
+
 private:
 	int timedRead();
 
     void write(uint8_t data);
-    
+
     void write(const char *str);
 
 	String generateKey();
 
 	WiFiClient *client;
+
+	bool secure;
 
 	String authorizationHeader = "";
 

--- a/app.ino
+++ b/app.ino
@@ -6,25 +6,14 @@
 #include "WebSocketClient.h"
 #include "libs/ArduinoJson.h"
 
+#include "config.h"
+
 #define DEBUG
 #ifdef DEBUG
 #define DEBUG_MSG Serial.println
 #else
 #define DEBUG_MSG(MSG)
 #endif
-
-/**
- * CONFIG
- */
-#define wifi_ssid ""
-#define wifi_password ""
-
-const String bot_token = "";
-// Intent options can be found in GatewayIntents.h
-const uint16_t gateway_intents = GUILD_MESSAGES_INTENT | GUILD_MESSAGE_TYPING_INTENT;
-/**
- * END CONFIG
- */
 
 void setup_wifi();
 
@@ -190,13 +179,15 @@ void loop()
 
                 if(hasWsSession)
                 {
-                    DEBUG_MSG("Send:: {\"op\":6,\"d\":{\"token\":\"" + bot_token + "\",\"session_id\":\"" + websocketSessionId + "\",\"seq\":\"" + String(lastWebsocketSequence, 10) + "\"}}");
-                    ws.send("{\"op\":6,\"d\":{\"token\":\"" + bot_token + "\",\"session_id\":\"" + websocketSessionId + "\",\"seq\":\"" + String(lastWebsocketSequence, 10) + "\"}}");
+                    String msg = "{\"op\":6,\"d\":{\"token\":\"" + String(bot_token) + "\",\"session_id\":\"" + websocketSessionId + "\",\"seq\":\"" + String(lastWebsocketSequence, 10) + "\"}}";
+                    DEBUG_MSG("Send:: " + msg);
+                    ws.send(msg);
                 }
                 else
                 {
-                    DEBUG_MSG("Send:: {\"op\":2,\"d\":{\"token\":\"" + bot_token + "\",\"intents\":" + gateway_intents + ",\"properties\":{\"$os\":\"linux\",\"$browser\":\"ESP8266\",\"$device\":\"ESP8266\"},\"compress\":false,\"large_threshold\":250}}");
-                    ws.send("{\"op\":2,\"d\":{\"token\":\"" + bot_token + "\",\"intents\":" + gateway_intents + ",\"properties\":{\"$os\":\"linux\",\"$browser\":\"ESP8266\",\"$device\":\"ESP8266\"},\"compress\":false,\"large_threshold\":250}}");
+                    String msg = "{\"op\":2,\"d\":{\"token\":\"" + String(bot_token) + "\",\"intents\":" + gateway_intents + ",\"properties\":{\"$os\":\"linux\",\"$browser\":\"ESP8266\",\"$device\":\"ESP8266\"},\"compress\":false,\"large_threshold\":250}}";
+                    DEBUG_MSG("Send:: " + msg);
+                    ws.send(msg);
                 }
 
                 lastHeartbeatSend = now;

--- a/app.ino
+++ b/app.ino
@@ -1,15 +1,15 @@
+#include "config.h"
+
 #include <HardwareSerial.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266HTTPClient.h>
 #include <WiFiClientSecure.h>
-#include "GatewayIntents.h"
 #include "WebSocketClient.h"
 #include "libs/ArduinoJson.h"
 
-#include "config.h"
 
-#define DEBUG
-#ifdef DEBUG
+#define DEBUG_APP
+#ifdef DEBUG_APP
 #define DEBUG_MSG Serial.println
 #else
 #define DEBUG_MSG(MSG)
@@ -112,6 +112,7 @@ void loop()
     if (!ws.isConnected())
     {
         Serial.println("connecting");
+        ws.setSecureFingerprint(certificateFingerprint);
         // It technically should fetch url from discord.com/api/gateway
         ws.connect("gateway.discord.gg", "/?v=8&encoding=json", 443);
     }

--- a/config.h
+++ b/config.h
@@ -3,11 +3,12 @@
 
 #include <Arduino.h>
 #include "privateConfig.h"
+#include "GatewayIntents.h"
 
 // Intent options can be found in GatewayIntents.h
 const uint16_t gateway_intents = GUILD_MESSAGES_INTENT | GUILD_MESSAGE_TYPING_INTENT;
 
-// discord.gg root certificate fingerprint: Baltimore CyberTrust Root
-const char * certificateFingerprint = "16af57a9f676b0ab126095aa5ebadef22ab31119d644ac95cd4b93dbf3f26aeb";
+// discord.gg certificate fingerprint
+const char * certificateFingerprint = "2c 9f 73 11 96 d1 d6 ab 00 4d 2e f1 2c 4e 12 37 96 17 27 93";
 
 #endif //CONFIG_H

--- a/config.h
+++ b/config.h
@@ -1,0 +1,13 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <Arduino.h>
+#include "privateConfig.h"
+
+// Intent options can be found in GatewayIntents.h
+const uint16_t gateway_intents = GUILD_MESSAGES_INTENT | GUILD_MESSAGE_TYPING_INTENT;
+
+// discord.gg root certificate fingerprint: Baltimore CyberTrust Root
+const char * certificateFingerprint = "16af57a9f676b0ab126095aa5ebadef22ab31119d644ac95cd4b93dbf3f26aeb";
+
+#endif //CONFIG_H

--- a/privateConfig.template.h
+++ b/privateConfig.template.h
@@ -1,0 +1,9 @@
+#ifndef PRIVATECONFIG_H
+#define PRIVATECONFIG_H
+
+const char * wifi_ssid = "";
+const char * wifi_password = "";
+
+const char * bot_token = "";
+
+#endif //PRIVATECONFIG_H


### PR DESCRIPTION
Update to ESP8266 Core v2.7.4 from the previous 2.4.2

- Moved config to separate header file
- Moved private config into a git ignored header file
- Add `discord.gg` SSL certificate fingerprint to allow for validation of connection

- Enabled SSL debug logs if using the VSCode Arduino extension