### PR TITLE
Update discord.gg certificate fingerprint

### DIFF
--- a/config.h
+++ b/config.h
@@ -9,6 +9,6 @@
 const uint16_t gateway_intents = GUILD_MESSAGES_INTENT | GUILD_MESSAGE_TYPING_INTENT;
 
 // discord.gg certificate fingerprint
-const char * certificateFingerprint = "2c 9f 73 11 96 d1 d6 ab 00 4d 2e f1 2c 4e 12 37 96 17 27 93";
+const char * certificateFingerprint = "8e fb bb d8 f0 69 9d 5b fe 30 ee bd 23 e0 7a 5b 56 41 86 e2";
 
 #endif //CONFIG_H


### PR DESCRIPTION
Update discord.gg SSL certificate fingerprint from 11 Dec 2021.

Expires on 11 Dec 2022.